### PR TITLE
Close OpenAI websocket on Twilio call end

### DIFF
--- a/main.py
+++ b/main.py
@@ -96,6 +96,12 @@ async def handle_media_stream(websocket: WebSocket):
                     elif data['event'] == 'mark':
                         if mark_queue:
                             mark_queue.pop(0)
+                    elif data['event'] == 'stop':
+                        print(f"Call ended, stream {stream_sid} stopped")
+                        if openai_ws.open:
+                            await openai_ws.close()
+                        await websocket.close()
+                        return
             except WebSocketDisconnect:
                 print("Client disconnected.")
                 if openai_ws.open:


### PR DESCRIPTION
On Twilio call end, the OpenAI websocket connection isn't closed, leading to an error happening in 30 minutes (maximum permissible OpenAI real-time session length). This also prevents graceful app exit on Ctrl+C.

The proposed change closes the connection on "stop" event from Twilio, received at a call end.